### PR TITLE
add tips for Hinet users in TW

### DIFF
--- a/Docs/Stock_ONU.md
+++ b/Docs/Stock_ONU.md
@@ -22,3 +22,4 @@ Use value from table below
 | HG8145V5         | HWTC12345678 | HWTC           | 15AD.A          | V5R020C00S060    | hezaika   | [TIME](https://www.time.com.my/personal/broadband/fibre-broadband) |
 | G-240G-E         | ALCL12345678 | ALCL           | 3FE48153CBAA    | 3FE46606BGCB45   | anime4000 | [TM](https://www.unifi.com.my/) |
 | HG6240A          | FHTT12345678 | FHTT           | WKE2.094.325A01 | RP2775           | lwk523    | [TM](https://www.unifi.com.my/) |
+| RTF8207W         | ASKY12345678 | ASKY           | REV1            | R8207WR210601    | pccr10001 | [Hinet](https://broadband.hinet.net/Broadband/internetManagement/internet/internet/internet_02.do) |

--- a/Docs/fakeO5.md
+++ b/Docs/fakeO5.md
@@ -29,3 +29,6 @@ flash set OMCI_OLT_MODE 1
 ```
 
 If still no luck, try `flash all` to print all then see any `OMCI_*`
+
+## For Users using CHT FTTH In Taiwan
+You can call to support center `0800-080-412` or using online chat from Hinet website to tell them "重整線路" to reset the OLT port and remove OMCI infomation lock.


### PR DESCRIPTION
I replaced RTF8207W from ASKEY to DFP-34X-2C2 successfully.
In TW, Hinet locks OMCI information on OLT but it can be unlock by calling support center.