### PR TITLE
Update software version for ZyXEL PMG4506-T20B

### DIFF
--- a/Docs/Stock_ONU.md
+++ b/Docs/Stock_ONU.md
@@ -29,6 +29,6 @@ Use value from table below
 | H660WM           | DSNW12345678 | DSNW           | H660WM          | H660WMR210825    | akw28888 | [Hinet](https://broadband.hinet.net/Broadband/internetManagement/internet/internet/internet_02.do) |
 | RV6699           | SCOM12345678 | SCOM           | V4              | SC3.0.14         | skon77 | [MGTS](https://mgts.ru/) |
 | RV6699           | SCOM12345678 | SCOM           | V4              | SC3.0.16         | skon77 | [MGTS](https://mgts.ru/) |
-| PMG4506-T20B     | ZYXE12345678 | ZYXE           | PMG4506-T20B    | P4506R220425     | akw28888 | [Hinet](https://broadband.hinet.net/Broadband/internetManagement/internet/internet/internet_02.do) |
+| PMG4506-T20B     | ZYXE12345678 | ZYXE           | PMG4506-T20B    | P4506R220712     | akw28888 | [Hinet](https://broadband.hinet.net/Broadband/internetManagement/internet/internet/internet_02.do) |
 | G040WQ           | NOKW12345678 | GMTK           | 3FE47772AAAA    | G040WQR201207    | pccr10001 | [Hinet](https://broadband.hinet.net/Broadband/internetManagement/internet/internet/internet_02.do) |
 | EDGG11000        | EDCR12345678 | EDCR           | GG-GAPL100v02   | GG-11000-C003    | Remooh    | [Vivo (Vivo 1/São Paulo region)](https://www.vivo.com.br/para-voce/produtos-e-servicos/para-casa/internet) |


### PR DESCRIPTION
OLT will push new firmware to pon stick if the software version is not the latest.
Bug: when the ODI stick receives new firmware through OMCI, the omci_app will use 100% CPU, then trigger the OOM killer.

Debug log:
```
[30.450] 0x0180 SWImage StartSwDownload(0x0000)
[30.550] 0x0180 SWImage StartSwDownloadRsp(0x0000)
[30.550] 0x0017 MacBriPortCfgData Create(0x0601,BridgeIdPtr=0x0001,PortNum=0x00,TPType=0x0b,TPPointer=0x0601,PortPriority=0x000a,PortPathCos
[30.550] 0x0017 MacBriPortCfgData CreateRsp(0x0601,Result=0x0)
[30.550] 0x0181 SWImage [30.550] 0x0182 SWImage [30.550] 0x0183 SWImage [30.560] 0x0184 SWImage [30.560] 0x0185 SWImage [30.560] 0x0186 SWIme [30.560] 0x018b SWImage [30.560] 0x018c SWImage [30.560] 0x018d SWImage [30.570] 0x018e SWImage [30.570] 0x018f SWImage [30.570] 0x0190 SW
[30.570] 0x0190 SWImage DownloadSectionRsp(0x0000)
```