### PR TITLE
make fix_vlan_tag.sh fully configurable

### DIFF
--- a/Tools/etc/scripts/fix_vlan_tag.sh
+++ b/Tools/etc/scripts/fix_vlan_tag.sh
@@ -1,27 +1,45 @@
 #!/bin/sh
 # VLAN Tag Fix: Fix VLAN wrong mapping
 # By inyourgroove
-# Additional VID check if config file is not empty by rajkosto
+# Additional configuration options added by rajkosto
 
 set -e
-configFname='/etc/config/fix_vlan'
+
+VLANS=""
+ENTITIES=""
+FWDOP=0x02
+# Allow overriding above variables from config file
+if [ -s /etc/config/fix_vlan ]; then
+    . /etc/config/fix_vlan
+fi
+
+FIX_ALL=0
+if [ -z "$VLANS" ] && [ -z "$ENTITIES" ]; then FIX_ALL=1; fi
 
 while true; do
 
   for _EntityID in $(omcicli mib get 84 | grep '^EntityID:' | awk '{print $2}'); do
 
     _FwdOp=$(omcicli mib get 84 ${_EntityID} | grep '^FwdOp:' | awk '{print $2}')
+    if [[ $((_FwdOp)) == $((FWDOP)) ]]; then continue; fi
 
-    if [[ ! -z ${_FwdOp} && ${_FwdOp} != '0x02' ]]; then
-      if [ -s "$configFname" ]; then #only change FwdOp VIDs specified in the file
-        _VlanId=$(omcicli mib get 84 ${_EntityID} | grep -o " VID [0-9]*" | awk '{print $2}')
-	if ! grep -o "\b${_VlanId}\b" "$configFname" > /dev/null; then
-          continue
+    _FixMe=$FIX_ALL
+    if [[ ${_FixMe} -eq 0 ]]; then
+        if echo "${ENTITIES}" | grep -q -o "\b${_EntityID}\b"; then
+            _FixMe=1
+        else
+            _VlanID=$(omcicli mib get 84 ${_EntityID} | grep -o " VID [0-9]*" | awk '{print $2}')
+            if echo "${VLANS}" | grep -q -o "\b${_VlanID}\b"; then
+                _FixMe=1
+            fi
         fi
-      fi
-      
-      omcicli mib set 84 ${_EntityID} FwdOp 0x02
     fi
+
+    if [[ ${_FixMe} -eq 0 ]]; then
+        continue
+    fi
+
+    omcicli mib set 84 ${_EntityID} FwdOp ${FWDOP}
 
   done
 


### PR DESCRIPTION
can set VLANS, ENTITIES, and FWDOP in /etc/config/fix_vlan instead of only newline delimited list of VLANs 
empty/blank file still means fix all entities/vlans

explanation of how to set these options here: https://github.com/rajkosto/RTL960x/blob/main/Firmware/DFP-34X-2C2/README.md in the `M110_sfp_ODI_220923FS.tar` section