### PR TITLE
Add hEX S 2025 to router list

### DIFF
--- a/Docs/2.5Gb.md
+++ b/Docs/2.5Gb.md
@@ -21,6 +21,7 @@ RTL960x has 3 different 2.5Gb Mode:
 | Mikrotik | Router | CCR1036-8G-2S+            | ✔ | ROS 7.11.2, Use `2.5G baseX` and `LAN_SDS_MODE 6` |
 | Mikrotik | Router | CCR2004-1G-12S+2XS        | ✔ | `98PX1012`, [follow @stich86 tweaks](https://github.com/Anime4000/RTL960x/issues/17#issuecomment-1101435506)|
 | Mikrotik | Router | CCR2116-12G-4S+           | ✔ | `flash set LAN_SDS_MODE 4` [@S8T8](https://github.com/Anime4000/RTL960x/issues/122?notification_referrer_id=NT_kwDOAB0f67I1MzMwMTg0Mjc4OjE5MDg3MTU#issuecomment-1435783070) |
+| Mikrotik | Router | hEX S 2025 (E60iUGS)      | ✔ | Use `2.5G baseX` and `LAN_SDS_MODE 6` |
 | Mikrotik | Switch | CRS305-1G-4S+IN           | ✔ | [`98PX1012`](https://forum.mikrotik.com/viewtopic.php?t=185066#p929130), [follow @stich86 tweaks](https://github.com/Anime4000/RTL960x/issues/17#issuecomment-1101435506) |
 | Mikrotik | Switch | CRS309-1G-8S+IN           | ✔ | [`98DX8208`](https://forum.mikrotik.com/viewtopic.php?t=185066#p929130), v7.11+ Use `2.5G baseX` and `LAN_SDS_MODE 6` | 
 | Mikrotik | Switch | CRS310-1G-5S-4S+IN        | ✔ | [`98DX226S`](https://forum.mikrotik.com/viewtopic.php?t=185066#p929130), v7.11+ Use `2.5G baseX` and `LAN_SDS_MODE 6` |


### PR DESCRIPTION
## Added the new(ish) hEX S 2025 to the list

setting `LAN_SDS_MODE 6` on the stick.  
then go into SFP settings, Ethernet.   
and turn off `Auto Neg` and set the speed to `2.5G BaseX` on the SFP1 interface   
<img width="1436" height="612" alt="CleanShot 2568-09-27 at 00 33 36@2x" src="https://github.com/user-attachments/assets/181b60bb-4bfc-482c-abec-11c048746c64" />

## Note
the firmware that comes with the device should work with no update required.
but there is a PPPoE bug that limit the throughput to ~600Mbps.  
it's fixed by updating to the latest stable ROS (7.19.6 at the time of writing), then export the config, reset and re-import everything.
after resetting I got ~900Mbps speed at ~40% CPU usage.   
I'm not sure of the maxium speed since the docker speedtest won't run because of 32bit CPU.